### PR TITLE
chore(codex): add CODEOWNERS and reviewer checklist

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,9 @@ netlify/** @brandonlacoste9-tech
 netlify.toml @brandonlacoste9-tech
 package*.json @brandonlacoste9-tech
 scripts/** @brandonlacoste9-tech
+
+# Codex playbooks and fraud detection systems
+/docs/codex/ @analytics-team @ops-team @brandonlacoste9-tech
+/supabase/functions/fraud-detection* @analytics-team @ops-team
+/scripts/run-fraud-canary.js @analytics-team @ops-team
+/scripts/format-fraud-report.js @analytics-team

--- a/.github/PULL_REQUEST_TEMPLATE/codex-canary-review.md
+++ b/.github/PULL_REQUEST_TEMPLATE/codex-canary-review.md
@@ -1,0 +1,11 @@
+## Codex Fraud Canary Review Checklist
+
+- [ ] Confirm `DRYRUN=1` for all `pull_request` runs
+- [ ] Verify production secrets NOT used in PR context or forks
+- [ ] Validate artifact contains expected fields (`fraud_summary.json`, `fraud-report.md`)
+- [ ] Check fixtures in `docs/codex/fixtures/fraud_canary/` are deterministic and safe
+- [ ] Confirm `scripts/run-fraud-canary.js` logs but does NOT auto-remediate
+- [ ] Verify `SUPABASE_KEY` usage is minimal and properly scoped
+- [ ] Review error handling and failure modes
+- [ ] Confirm artifact retention period is appropriate (30 days)
+- [ ] Ensure `CODEOWNERS` includes the right teams (analytics-team, ops-team)

--- a/docs/codex/README.md
+++ b/docs/codex/README.md
@@ -1,0 +1,48 @@
+# Codex Fraud Canary — Playbook Overview
+
+This directory contains the **Codex Fraud Canary**: a deterministic, auditable playbook
+that exercises the fraud-detection pipeline end-to-end and produces human-reviewable reports.
+
+## What’s in this folder
+
+- `playbooks/fraud_canary.yaml` — canonical playbook definition and triggers.
+- `fixtures/fraud_canary/` — deterministic campaign fixtures for repeatable tests.
+- `reports/` — artifacts produced by runs (uploaded by CI).
+- `README.md` — this file.
+
+## Goals
+
+- Continuously validate fraud detection logic (scoring, thresholds, indicators).
+- Produce a digestible report with severity assessment and remediation suggestions.
+- Keep PR runs safe (DRYRUN) and nightly runs configurable for production checks.
+
+## How to run
+
+### Locally (dry-run)
+````bash
+# run the canary in dry-run mode (no production writes)
+node scripts/run-fraud-canary.js --fixtures docs/codex/fixtures/fraud_canary/sample_campaigns.json --out reports/fraud_summary.json --dry-run
+node scripts/format-fraud-report.js --input reports/fraud_summary.json --output reports/fraud-report.md
+````
+
+### On CI (recommended)
+
+* PR runs are configured to run in **DRYRUN** mode and produce artifacts (no prod writes).
+* Nightly runs can be enabled to call the production API by setting `USE_PROD_API=true` in the workflow or using the workflow_dispatch `use_prod` input (manual opt-in required).
+
+## Secrets needed for production runs
+
+* `SUPABASE_URL`
+* `SUPABASE_KEY` (service or function key)
+* `SLACK_WEBHOOK_URL` (optional for notifications)
+
+## Safety notes
+
+* PR runs MUST run with `DRYRUN=1` and must never expose secrets to forked-code contexts.
+* The canary logs created items to `created-issues.jsonl` and uploads artifacts for auditing.
+* This playbook **does not** auto-remediate. Any operational actions require human approval.
+
+## Contact
+
+For questions, tag: `@analytics-team`, `@ops-team`, or `@brandonlacoste9-tech`.
+


### PR DESCRIPTION
## Summary
- add codex-specific CODEOWNERS entries for the fraud canary assets
- add a fraud canary pull request review checklist for codex reviewers
- provide a README orienting reviewers and operators to the codex fraud canary playbook

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_6901960f7df4832e83e59d21e4eed871