### PR TITLE
refactor(functions): centralize json response helpers

### DIFF
--- a/netlify/functions/github-webhook.ts
+++ b/netlify/functions/github-webhook.ts
@@ -1,18 +1,16 @@
 import type { Handler } from '@netlify/functions';
+import { errorResponse, jsonResponse } from './utils/response';
 
 export const handler: Handler = async (event) => {
   if (event.httpMethod !== 'POST') {
-    return {
-      statusCode: 405,
-      body: JSON.stringify({ error: 'Method not allowed' })
-    };
+    return errorResponse('Method not allowed', { statusCode: 405 });
   }
 
   try {
     const githubEvent = event.headers['x-github-event'];
     const deliveryId = event.headers['x-github-delivery'];
     const payload = JSON.parse(event.body || '{}');
-    
+
     console.log('📥 Webhook received:', {
       event: githubEvent,
       deliveryId,
@@ -21,26 +19,17 @@ export const handler: Handler = async (event) => {
       timestamp: new Date().toISOString()
     });
 
-    return {
-      statusCode: 200,
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        received: true,
-        deliveryId,
-        event: githubEvent,
-        message: '🧠 AdgenXAI Sensory Cortex - Event Processed',
-        timestamp: new Date().toISOString()
-      })
-    };
-    
+    return jsonResponse({
+      received: true,
+      deliveryId,
+      event: githubEvent,
+      message: '🧠 AdgenXAI Sensory Cortex - Event Processed',
+      timestamp: new Date().toISOString()
+    });
   } catch (error) {
     console.error('❌ Error:', error);
-    return {
-      statusCode: 500,
-      body: JSON.stringify({
-        error: 'Internal server error',
-        message: error instanceof Error ? error.message : 'Unknown'
-      })
-    };
+    return errorResponse('Internal server error', { statusCode: 500 }, {
+      message: error instanceof Error ? error.message : 'Unknown'
+    });
   }
 };

--- a/netlify/functions/health.ts
+++ b/netlify/functions/health.ts
@@ -1,29 +1,25 @@
 import type { Handler } from '@netlify/functions';
+import { jsonResponse } from './utils/response';
 
-export const handler: Handler = async () => {
-  return {
-    statusCode: 200,
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      status: 'healthy',
-      timestamp: new Date().toISOString(),
-      version: '1.0.0',
-      cortex: {
-        webhook: {
-          configured: true,
-          processing: process.env.ENABLE_WEBHOOK_PROCESSING === 'true'
-        },
-        telemetry: {
-          enabled: true,
-          retention: '30 days'
-        }
+export const handler: Handler = async () =>
+  jsonResponse({
+    status: 'healthy',
+    timestamp: new Date().toISOString(),
+    version: '1.0.0',
+    cortex: {
+      webhook: {
+        configured: true,
+        processing: process.env.ENABLE_WEBHOOK_PROCESSING === 'true'
       },
-      endpoints: {
-        webhook: '/.netlify/functions/github-webhook',
-        telemetry: '/.netlify/functions/webhook-telemetry',
-        dashboard: '/.netlify/functions/telemetry-dashboard',
-        health: '/.netlify/functions/health'
+      telemetry: {
+        enabled: true,
+        retention: '30 days'
       }
-    })
-  };
-};
+    },
+    endpoints: {
+      webhook: '/.netlify/functions/github-webhook',
+      telemetry: '/.netlify/functions/webhook-telemetry',
+      dashboard: '/.netlify/functions/telemetry-dashboard',
+      health: '/.netlify/functions/health'
+    }
+  });

--- a/netlify/functions/utils/response.ts
+++ b/netlify/functions/utils/response.ts
@@ -1,0 +1,35 @@
+import type { HandlerResponse } from '@netlify/functions';
+
+const JSON_HEADER = { 'Content-Type': 'application/json' } as const;
+
+export interface JsonResponseInit {
+  statusCode?: number;
+  headers?: Record<string, string>;
+}
+
+export const jsonResponse = (
+  body: unknown,
+  { statusCode = 200, headers = {} }: JsonResponseInit = {}
+): HandlerResponse => ({
+  statusCode,
+  headers: {
+    ...JSON_HEADER,
+    ...headers
+  },
+  body: JSON.stringify(body)
+});
+
+export const errorResponse = (
+  message: string,
+  init: JsonResponseInit = {},
+  details?: Record<string, unknown>
+): HandlerResponse => {
+  const { statusCode = 500, headers } = init;
+  return jsonResponse(
+    {
+      error: message,
+      ...(details ?? {})
+    },
+    { statusCode, headers }
+  );
+};

--- a/netlify/functions/webhook-telemetry.ts
+++ b/netlify/functions/webhook-telemetry.ts
@@ -1,25 +1,23 @@
 import type { Handler } from '@netlify/functions';
+import { jsonResponse } from './utils/response';
 
 export const handler: Handler = async () => {
   // Minimal stub telemetry (upgrade later to read from storage/logs)
   const now = new Date();
-  const start = new Date(now.getTime() - 24*60*60*1000);
+  const start = new Date(now.getTime() - 24 * 60 * 60 * 1000);
   const data = {
     stats: {
       totalEvents: 1, // bump as you add storage; proves the pipe works
       processing: {
         mode: 'observation',
-        enabled: process.env.ENABLE_WEBHOOK_PROCESSING === 'true',
+        enabled: process.env.ENABLE_WEBHOOK_PROCESSING === 'true'
       },
       timeRange: {
         start: start.toISOString(),
-        end: now.toISOString(),
-      },
-    },
+        end: now.toISOString()
+      }
+    }
   };
-  return {
-    statusCode: 200,
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
-  };
+
+  return jsonResponse(data);
 };


### PR DESCRIPTION
## Summary
- add a shared JSON response utility for Netlify handlers
- update webhook, health, and telemetry functions to use the shared helper
- improve error responses with consistent payloads

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_6902acdfd7f4832eb94278260238c7d2