### PR TITLE
Enhance hero aurora previews and palette-aware top bar

### DIFF
--- a/app/components/HeroAurora.tsx
+++ b/app/components/HeroAurora.tsx
@@ -1,3 +1,30 @@
+const exportTargets = [
+  {
+    name: "TikTok",
+    caption: "9:16 vertical · Auto-captioned hook",
+    badge: "Vertical Spotlight",
+    accent: "from-[#35E3FF]/80 via-[#7C4DFF]/70 to-[#FFD76A]/70",
+  },
+  {
+    name: "Instagram",
+    caption: "Square carousel · Swipe-ready frames",
+    badge: "Carousel Stack",
+    accent: "from-[#FF8BCF]/80 via-[#7C4DFF]/60 to-[#35E3FF]/60",
+  },
+  {
+    name: "YouTube",
+    caption: "16:9 storyboards · B-roll suggestions",
+    badge: "Storyboard",
+    accent: "from-[#FFD76A]/80 via-[#35E3FF]/60 to-[#7C4DFF]/60",
+  },
+  {
+    name: "X",
+    caption: "Copy + headline · Trend-aware hashtags",
+    badge: "Thread Draft",
+    accent: "from-[#7C4DFF]/80 via-[#35E3FF]/60 to-[#FFD76A]/60",
+  },
+];
+
 export default function HeroAurora() {
   return (
     <section className="relative overflow-hidden bg-white">
@@ -9,6 +36,8 @@ export default function HeroAurora() {
                         bg-[radial-gradient(60%_60%_at_60%_40%,rgba(124,77,255,.24),transparent)]" />
         <div className="absolute bottom-[-15%] left-1/2 -translate-x-1/2 h-[60vh] w-[90vw] rounded-full blur-3xl
                         bg-[radial-gradient(60%_60%_at_50%_50%,rgba(255,215,106,.22),transparent)]" />
+        <div className="absolute inset-0 motion-safe:animate-aurora-drift mix-blend-screen
+                        bg-[radial-gradient(55%_75%_at_30%_30%,rgba(124,77,255,.12),transparent)]" />
       </div>
 
       <div className="relative max-w-7xl mx-auto px-6 pt-20 pb-12 md:pt-28">
@@ -41,10 +70,13 @@ export default function HeroAurora() {
               Explore Features
             </a>
           </div>
+          <p className="mt-3 text-sm text-black/60">
+            No credit card needed · Launch with pre-built personas in under five minutes.
+          </p>
         </div>
 
         {/* Hero image (placeholder SVG; swap to your final JPEG any time) */}
-        <div className="mt-10 md:mt-14">
+        <div className="mt-10 md:mt-14 relative">
           <img
             src="/hero-aurora-studio@1792x1024.svg"
             alt="AdGenXAI studio with aurora backdrop and creator widgets"
@@ -52,16 +84,39 @@ export default function HeroAurora() {
                        shadow-[0_10px_60px_rgba(124,77,255,.2)]"
             loading="eager"
           />
+          <div className="pointer-events-none absolute inset-0">
+            <div className="aurora-orbit-card" aria-hidden>
+              <span className="aurora-orbit-card__title">Assemble Campaign</span>
+              <span className="aurora-orbit-card__meta">Drag modules · AI suggests next step</span>
+            </div>
+            <div className="aurora-orbit-card aurora-orbit-card--right" aria-hidden>
+              <span className="aurora-orbit-card__title">Persona Sync</span>
+              <span className="aurora-orbit-card__meta">Auto-matched tone + hooks</span>
+            </div>
+          </div>
         </div>
 
         {/* Export bar */}
         <div className="mt-6 flex items-center gap-3 text-sm text-black/70">
           <span className="px-2 py-1 rounded-full border border-black/10 bg-white/60">Export</span>
           <div className="flex gap-2">
-            {["TikTok","Instagram","YouTube","X"].map(name => (
-              <span key={name} className="rounded-xl border border-black/10 bg-white/70 px-3 py-1 hover:shadow
-                                          hover:shadow-[0_0_24px_rgba(124,77,255,.20)] transition-all">
-                {name}
+            {exportTargets.map((item) => (
+              <span
+                key={item.name}
+                className="group relative rounded-xl border border-black/10 bg-white/70 px-3 py-1 transition-all
+                           hover:shadow hover:shadow-[0_0_24px_rgba(124,77,255,.20)]"
+              >
+                {item.name}
+                <span
+                  role="tooltip"
+                  className="pointer-events-none absolute left-1/2 top-full z-10 mt-2 hidden w-48 -translate-x-1/2 rounded-2xl border
+                             border-black/10 bg-white/90 p-3 text-left text-xs text-black/80 shadow-lg backdrop-blur-md
+                             group-hover:block"
+                >
+                  <span className="block text-[10px] uppercase tracking-[0.2em] text-black/50">{item.badge}</span>
+                  <span className="mt-1 block font-semibold">{item.name} preview</span>
+                  <span className={`mt-2 block rounded-xl bg-gradient-to-br ${item.accent} p-3 text-[11px] leading-tight text-[#071022] shadow-inner`}>{item.caption}</span>
+                </span>
               </span>
             ))}
           </div>

--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -5,8 +5,10 @@ import { getInitialTheme, setTheme, applyTheme, Theme } from "@/lib/theme";
 
 export default function TopBar({
   onOpenPalette,
+  paletteOpen = false,
 }: {
   onOpenPalette: () => void;
+  paletteOpen?: boolean;
 }) {
   const [theme, setLocalTheme] = useState<Theme>("light");
 
@@ -22,15 +24,25 @@ export default function TopBar({
     setTheme(next);
   }
 
+  const themeLabel = theme === "light" ? "Light" : "Dark";
+
   return (
-    <header className="sticky top-0 z-40 border-b" style={{borderColor:"var(--border)", background:"color-mix(in oklab, var(--bg) 85%, transparent)"}}>
+    <header
+      className={`sticky top-0 z-40 border-b backdrop-blur-xl transition-all duration-300 ${paletteOpen ? "opacity-80 saturate-[0.75]" : ""}`}
+      style={{
+        borderColor: "var(--border)",
+        background: "color-mix(in oklab, var(--bg) 82%, transparent)",
+        boxShadow: paletteOpen ? "0 20px 40px rgba(7,16,34,0.15)" : "0 10px 30px rgba(7,16,34,0.08)",
+      }}
+      data-palette-open={paletteOpen ? "true" : undefined}
+    >
       <div className="max-w-7xl mx-auto px-4 md:px-6 h-14 flex items-center justify-between">
         <a href="/" className="flex items-center gap-2 font-semibold" aria-label="AdGenXAI home">
           <span className="inline-block h-6 w-6 rounded-full shadow-[0_0_24px_rgba(124,77,255,.4)]" style={{background:"radial-gradient(60% 60% at 50% 50%, #35E3FF 0%, #7C4DFF 50%, #FFD76A 100%)"}}/>
           <span>AdGenXAI</span>
         </a>
 
-        <div className="flex items-center gap-2">
+        <div className={`flex items-center gap-2 transition-opacity ${paletteOpen ? "opacity-70" : ""}`}>
           <input
             type="search"
             role="searchbox"
@@ -54,12 +66,15 @@ export default function TopBar({
             title="Open palette (⌘K)"
           >⌘K</button>
           <button
-            className="rounded-lg border px-3 py-1.5 text-sm"
+            className="flex items-center gap-1 rounded-lg border px-3 py-1.5 text-sm transition-colors"
             style={{background:"var(--card)", borderColor:"var(--border)", color:"var(--text)"}}
             onClick={toggleTheme}
-            aria-label="Toggle theme"
+            aria-label={`Toggle theme (currently ${themeLabel})`}
             title="Toggle theme"
-          >{theme === "light" ? "☀️" : "🌙"}</button>
+          >
+            <span aria-hidden>{theme === "light" ? "☀️" : "🌙"}</span>
+            <span className="text-xs font-medium tracking-wide">{themeLabel}</span>
+          </button>
         </div>
       </div>
     </header>

--- a/app/globals.css
+++ b/app/globals.css
@@ -36,3 +36,83 @@ html, body {
   outline: 2px solid #7C4DFF;
   outline-offset: 2px;
 }
+
+@layer utilities {
+  @keyframes aurora-drift {
+    0% {
+      transform: translate3d(-10%, -6%, 0) scale(1.05) rotate(0deg);
+      opacity: 0.35;
+    }
+    50% {
+      transform: translate3d(6%, 4%, 0) scale(1.12) rotate(2deg);
+      opacity: 0.55;
+    }
+    100% {
+      transform: translate3d(-10%, -6%, 0) scale(1.05) rotate(-1deg);
+      opacity: 0.35;
+    }
+  }
+
+  .animate-aurora-drift {
+    animation: aurora-drift 22s ease-in-out infinite;
+  }
+}
+
+@layer components {
+  .aurora-orbit-card {
+    position: absolute;
+    top: 10%;
+    left: 9%;
+    width: min(240px, 40%);
+    border-radius: 18px;
+    padding: 12px 14px;
+    background: color-mix(in oklab, rgba(255, 255, 255, 0.86) 90%, transparent);
+    border: 1px solid rgba(7, 16, 34, 0.08);
+    box-shadow: 0 18px 46px rgba(124, 77, 255, 0.22);
+    backdrop-filter: blur(18px);
+    transform: translate3d(0, 0, 0);
+    animation: orbit-drift 16s ease-in-out infinite;
+  }
+
+  .aurora-orbit-card--right {
+    left: auto;
+    right: 8%;
+    top: 54%;
+    animation-delay: -6s;
+  }
+
+  .aurora-orbit-card__title {
+    display: block;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #071022;
+  }
+
+  .aurora-orbit-card__meta {
+    display: block;
+    margin-top: 4px;
+    font-size: 0.7rem;
+    color: rgba(7, 16, 34, 0.55);
+  }
+
+  @keyframes orbit-drift {
+    0% {
+      transform: translate3d(0, 0, 0) scale(1);
+      opacity: 0.92;
+    }
+    50% {
+      transform: translate3d(6%, -4%, 0) scale(1.05);
+      opacity: 1;
+    }
+    100% {
+      transform: translate3d(0, 0, 0) scale(1);
+      opacity: 0.92;
+    }
+  }
+
+  @media (max-width: 768px) {
+    .aurora-orbit-card {
+      display: none;
+    }
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,7 +35,7 @@ export default function Page() {
 
   return (
     <main>
-      <TopBar onOpenPalette={() => setOpen(true)} />
+      <TopBar onOpenPalette={() => setOpen(true)} paletteOpen={open} />
       <div className="max-w-7xl mx-auto px-4 md:px-6 pt-4 flex justify-end">
         <ShareButton />
       </div>


### PR DESCRIPTION
## Summary
- add ambient aurora motion, reassurance copy, and interactive export previews to the hero section
- layer animated orbit cards through shared global styles for motion-safe interactions
- refine the top navigation with theme labels, palette-aware dimming, and blur depth cues

## Testing
- npm run test *(fails: RangeError: Invalid count value: Infinity from vitest renderer)*

------
https://chatgpt.com/codex/tasks/task_b_6906fe140ad8832e8d2d43de866a3457