### PR TITLE
Add client-side theme helpers for TopBar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,7 @@ Thumbs.db
 # IDE
 .vscode/settings.json
 *.log
+
+# Allow Next.js app libraries
+!app/lib/
+!app/lib/**/*.ts

--- a/app/lib/theme.ts
+++ b/app/lib/theme.ts
@@ -1,0 +1,56 @@
+export type Theme = "light" | "dark";
+
+const STORAGE_KEY = "adgenxai-theme";
+const MEDIA_QUERY = "(prefers-color-scheme: dark)";
+
+function isTheme(value: unknown): value is Theme {
+  return value === "light" || value === "dark";
+}
+
+export function getInitialTheme(): Theme {
+  if (typeof window === "undefined") {
+    return "light";
+  }
+
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (isTheme(stored)) {
+      return stored;
+    }
+  } catch {
+    // Ignore storage access issues (private mode, etc.) and fallback to system preference
+  }
+
+  try {
+    if (window.matchMedia(MEDIA_QUERY).matches) {
+      return "dark";
+    }
+  } catch {
+    // matchMedia can throw in older browsers; fall back to light theme
+  }
+
+  return "light";
+}
+
+export function applyTheme(theme: Theme) {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  document.documentElement.dataset.theme = theme;
+  document.documentElement.style.colorScheme = theme;
+}
+
+export function setTheme(theme: Theme) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  applyTheme(theme);
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  } catch {
+    // Ignore storage write failures (e.g. private browsing)
+  }
+}


### PR DESCRIPTION
## Summary
- add a client-side theme helper module under app/lib to back the TopBar toggle
- apply the selected theme to the document root while persisting the choice
- refine .gitignore so app/lib helpers are included in source control

## Testing
- `npm test` *(fails: Vitest RangeError: Invalid count value: Infinity when running under Node.js v22.19.0)*

------
https://chatgpt.com/codex/tasks/task_b_69056a25c380832e81f9ef1c0d50121f