### PR TITLE
feat: persist webhook events and expose richer telemetry

### DIFF
--- a/netlify/functions/github-webhook.ts
+++ b/netlify/functions/github-webhook.ts
@@ -1,4 +1,121 @@
 import type { Handler } from '@netlify/functions';
+import { z } from 'zod';
+
+import { buildEventKey, getEventsStore, storeName } from './utils/events-store';
+
+type Headers = Record<string, string | undefined>;
+
+const payloadSchema = z
+  .object({
+    action: z.string().optional(),
+    repository: z
+      .object({
+        full_name: z.string().optional(),
+        html_url: z.string().optional()
+      })
+      .optional(),
+    sender: z
+      .object({
+        login: z.string().optional(),
+        html_url: z.string().optional()
+      })
+      .optional()
+  })
+  .passthrough();
+
+type GithubWebhookPayload = z.infer<typeof payloadSchema>;
+
+type StorageResult = {
+  stored: boolean;
+  key: string | null;
+  error?: string;
+};
+
+const headerValue = (headers: Headers, name: string): string | undefined => {
+  const lower = name.toLowerCase();
+  return headers[name] ?? headers[lower] ?? headers[name.toUpperCase()];
+};
+
+const parsePayload = (body: string | null): GithubWebhookPayload | null => {
+  if (!body) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(body);
+    const result = payloadSchema.safeParse(parsed);
+    if (!result.success) {
+      console.warn('Invalid GitHub webhook payload shape', result.error.flatten());
+      return null;
+    }
+
+    return result.data;
+  } catch (error) {
+    console.warn('Failed to parse GitHub webhook payload', error);
+    return null;
+  }
+};
+
+const persistEvent = async (
+  deliveryId: string | undefined,
+  eventType: string | undefined,
+  payload: GithubWebhookPayload,
+  receivedAt: string
+): Promise<StorageResult> => {
+  const store = getEventsStore();
+  if (!store) {
+    return {
+      stored: false,
+      key: null,
+      error: `Blob store "${storeName}" is not configured`
+    };
+  }
+
+  const key = buildEventKey(deliveryId);
+  const summary = {
+    deliveryId: deliveryId ?? null,
+    event: eventType ?? 'unknown',
+    action: payload.action ?? null,
+    repository: payload.repository?.full_name ?? null,
+    sender: payload.sender?.login ?? null,
+    receivedAt
+  };
+
+  const metadata: Record<string, unknown> = {
+    receivedAt
+  };
+
+  if (summary.event) {
+    metadata.eventType = summary.event;
+  }
+
+  if (summary.action) {
+    metadata.action = summary.action;
+  }
+
+  if (summary.repository) {
+    metadata.repository = summary.repository;
+  }
+
+  if (summary.sender) {
+    metadata.sender = summary.sender;
+  }
+
+  try {
+    await store.setJSON(key, { ...summary, payload }, { metadata });
+    return {
+      stored: true,
+      key
+    };
+  } catch (error) {
+    console.error('Failed to persist webhook payload to blob store', error);
+    return {
+      stored: false,
+      key,
+      error: error instanceof Error ? error.message : 'Unknown storage error'
+    };
+  }
+};
 
 export const handler: Handler = async (event) => {
   if (event.httpMethod !== 'POST') {
@@ -8,39 +125,46 @@ export const handler: Handler = async (event) => {
     };
   }
 
-  try {
-    const githubEvent = event.headers['x-github-event'];
-    const deliveryId = event.headers['x-github-delivery'];
-    const payload = JSON.parse(event.body || '{}');
-    
-    console.log('📥 Webhook received:', {
-      event: githubEvent,
-      deliveryId,
-      repository: payload.repository?.full_name,
-      action: payload.action,
-      timestamp: new Date().toISOString()
-    });
+  const payload = parsePayload(event.body ?? null);
 
+  if (!payload) {
     return {
-      statusCode: 200,
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        received: true,
-        deliveryId,
-        event: githubEvent,
-        message: '🧠 AdgenXAI Sensory Cortex - Event Processed',
-        timestamp: new Date().toISOString()
-      })
-    };
-    
-  } catch (error) {
-    console.error('❌ Error:', error);
-    return {
-      statusCode: 500,
-      body: JSON.stringify({
-        error: 'Internal server error',
-        message: error instanceof Error ? error.message : 'Unknown'
-      })
+      statusCode: 400,
+      body: JSON.stringify({ error: 'Invalid JSON payload' })
     };
   }
+
+  const githubEvent = headerValue(event.headers ?? {}, 'x-github-event');
+  const deliveryId = headerValue(event.headers ?? {}, 'x-github-delivery');
+  const receivedAt = new Date().toISOString();
+
+  console.log('📥 Webhook received:', {
+    event: githubEvent,
+    deliveryId,
+    repository: payload.repository?.full_name,
+    action: payload.action,
+    timestamp: receivedAt
+  });
+
+  const storage = await persistEvent(deliveryId, githubEvent, payload, receivedAt);
+
+  const responseBody = {
+    received: true,
+    deliveryId: deliveryId ?? null,
+    event: githubEvent ?? 'unknown',
+    message: '🧠 AdgenXAI Sensory Cortex - Event Processed',
+    repository: payload.repository?.full_name ?? null,
+    action: payload.action ?? null,
+    sender: payload.sender?.login ?? null,
+    timestamp: receivedAt,
+    storage
+  };
+
+  const statusCode = storage.stored ? 200 : 202;
+
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(responseBody)
+  };
 };

--- a/netlify/functions/utils/events-store.ts
+++ b/netlify/functions/utils/events-store.ts
@@ -1,0 +1,35 @@
+import { getStore } from '@netlify/blobs';
+
+export type EventsStore = ReturnType<typeof getStore>;
+
+let cachedStore: EventsStore | null | undefined;
+
+const STORE_NAME = 'adgenxai-webhook-events';
+
+export const getEventsStore = (): EventsStore | null => {
+  if (cachedStore !== undefined) {
+    return cachedStore;
+  }
+
+  try {
+    cachedStore = getStore({ name: STORE_NAME });
+  } catch (error) {
+    console.error('Failed to initialize webhook events store', error);
+    cachedStore = null;
+  }
+
+  return cachedStore;
+};
+
+export const buildEventKey = (deliveryId: string | undefined): string => {
+  if (deliveryId) {
+    const sanitized = deliveryId.trim().replace(/[^a-zA-Z0-9-_.]/g, '_');
+    if (sanitized.length > 0) {
+      return `events/${sanitized}`;
+    }
+  }
+
+  return `events/generated-${Date.now()}`;
+};
+
+export const storeName = STORE_NAME;

--- a/netlify/functions/webhook-telemetry.ts
+++ b/netlify/functions/webhook-telemetry.ts
@@ -1,25 +1,198 @@
 import type { Handler } from '@netlify/functions';
 
-export const handler: Handler = async () => {
-  // Minimal stub telemetry (upgrade later to read from storage/logs)
-  const now = new Date();
-  const start = new Date(now.getTime() - 24*60*60*1000);
-  const data = {
-    stats: {
-      totalEvents: 1, // bump as you add storage; proves the pipe works
-      processing: {
-        mode: 'observation',
-        enabled: process.env.ENABLE_WEBHOOK_PROCESSING === 'true',
-      },
-      timeRange: {
-        start: start.toISOString(),
-        end: now.toISOString(),
-      },
-    },
-  };
+import { getEventsStore, storeName } from './utils/events-store';
+
+type CountMap = Record<string, number>;
+
+type TelemetryEvent = {
+  key: string;
+  deliveryId: string | null;
+  eventType: string;
+  action: string | null;
+  repository: string | null;
+  sender: string | null;
+  receivedAt: string | null;
+};
+
+const increment = (map: CountMap, key: string | null) => {
+  if (!key) {
+    return;
+  }
+
+  map[key] = (map[key] ?? 0) + 1;
+};
+
+const coerceString = (value: unknown): string | null => {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value;
+  }
+
+  return null;
+};
+
+const computeTelemetry = async () => {
+  const store = getEventsStore();
+  if (!store) {
+    return {
+      events: [],
+      configured: false
+    };
+  }
+
+  const { blobs } = await store.list({ prefix: 'events/' });
+  const events: TelemetryEvent[] = [];
+
+  for (const blob of blobs) {
+    const result = await store.getWithMetadata(blob.key, { type: 'json' });
+    if (!result) {
+      continue;
+    }
+
+    const { data, metadata } = result;
+    const parsed = typeof data === 'object' && data !== null ? (data as Record<string, unknown>) : {};
+    const meta = (metadata as Record<string, unknown> | undefined) ?? {};
+
+    const eventType = coerceString(meta['eventType']) ?? coerceString(parsed['event']) ?? 'unknown';
+    const action = coerceString(meta['action']) ?? coerceString(parsed['action']);
+    const repository = coerceString(meta['repository']) ?? coerceString(parsed['repository']);
+    const senderFromMeta = coerceString(meta['sender']);
+    const senderFromParsed = coerceString(parsed['sender']);
+    const senderFromObject = typeof parsed['sender'] === 'object' && parsed['sender'] !== null
+      ? coerceString((parsed['sender'] as Record<string, unknown>)['login'])
+      : null;
+    const sender = senderFromMeta ?? senderFromParsed ?? senderFromObject;
+    const receivedAt = coerceString(meta['receivedAt']) ?? coerceString(parsed['receivedAt']);
+    const deliveryId = coerceString(parsed['deliveryId']);
+
+    events.push({
+      key: blob.key,
+      eventType,
+      action,
+      repository,
+      sender,
+      receivedAt,
+      deliveryId: deliveryId ?? null
+    });
+  }
+
   return {
-    statusCode: 200,
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
+    events,
+    configured: true
   };
+};
+
+export const handler: Handler = async () => {
+  try {
+    const { events, configured } = await computeTelemetry();
+
+    if (!configured) {
+      return {
+        statusCode: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          stats: {
+            totalEvents: 0,
+            eventTypes: {},
+            actions: {},
+            repositories: {},
+            processing: {
+              mode: 'observation',
+              enabled: process.env.ENABLE_WEBHOOK_PROCESSING === 'true'
+            },
+            timeRange: {
+              start: null,
+              end: null
+            }
+          },
+          storage: {
+            configured: false,
+            storeName
+          },
+          recentEvents: []
+        })
+      };
+    }
+
+    const eventTypeCounts: CountMap = {};
+    const actionCounts: CountMap = {};
+    const repositoryCounts: CountMap = {};
+    const validTimestamps: number[] = [];
+
+    for (const event of events) {
+      increment(eventTypeCounts, event.eventType);
+      increment(actionCounts, event.action);
+      increment(repositoryCounts, event.repository);
+
+      if (event.receivedAt) {
+        const timestamp = Date.parse(event.receivedAt);
+        if (!Number.isNaN(timestamp)) {
+          validTimestamps.push(timestamp);
+        }
+      }
+    }
+
+    validTimestamps.sort((a, b) => a - b);
+
+    const sortedEvents = events
+      .slice()
+      .sort((a, b) => {
+        const left = a.receivedAt ? Date.parse(a.receivedAt) : 0;
+        const right = b.receivedAt ? Date.parse(b.receivedAt) : 0;
+        return right - left;
+      });
+
+    const recentEvents = sortedEvents.slice(0, 5).map((event) => ({
+      deliveryId: event.deliveryId,
+      event: event.eventType,
+      action: event.action,
+      repository: event.repository,
+      sender: event.sender,
+      receivedAt: event.receivedAt
+    }));
+
+    const timeRange = validTimestamps.length > 0
+      ? {
+          start: new Date(validTimestamps[0]).toISOString(),
+          end: new Date(validTimestamps[validTimestamps.length - 1]).toISOString()
+        }
+      : {
+          start: null,
+          end: null
+        };
+
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        stats: {
+          totalEvents: events.length,
+          eventTypes: eventTypeCounts,
+          actions: actionCounts,
+          repositories: repositoryCounts,
+          processing: {
+            mode: 'observation',
+            enabled: process.env.ENABLE_WEBHOOK_PROCESSING === 'true'
+          },
+          timeRange
+        },
+        storage: {
+          configured: true,
+          storeName,
+          items: events.length
+        },
+        recentEvents
+      })
+    };
+  } catch (error) {
+    console.error('Failed to compute webhook telemetry', error);
+
+    return {
+      statusCode: 500,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        error: 'Failed to compute webhook telemetry',
+        message: error instanceof Error ? error.message : 'Unknown error'
+      })
+    };
+  }
 };


### PR DESCRIPTION
## Summary
- persist GitHub webhook payloads into a Netlify Blobs store with metadata for follow-up analysis
- expose telemetry that reads from the blob store to report counts, repositories, actions, and recent events
- share a utility for creating blob-store keys and reusing the configured store across functions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_690187cd6e54832e8ff42fbddfc29cb4