### PR TITLE
Add Cloudflare Zero Trust overview documentation

### DIFF
--- a/docs/cloudflare-zero-trust-overview.md
+++ b/docs/cloudflare-zero-trust-overview.md
@@ -1,0 +1,95 @@
+---
+title: Overview · Cloudflare Zero Trust docs
+description: Learn how to secure self-hosted and SaaS applications with Cloudflare Zero Trust. Configure a unified dashboard for seamless access and security.
+lastUpdated: 2025-10-27T15:00:52.000Z
+chatbotDeprioritize: false
+source_url:
+  html: https://developers.cloudflare.com/cloudflare-one/
+  md: https://developers.cloudflare.com/cloudflare-one/index.md
+---
+
+Secure your organization with Cloudflare Zero Trust — a cloud security model that replaces legacy perimeters with Cloudflare’s global network.
+
+Available on all plans
+
+Cloudflare Zero Trust is part of Cloudflare One, our name for the Secure Access Service Edge (SASE) platform that protects enterprise applications, users, devices, and networks.
+
+By progressively adopting Cloudflare One, organizations can move away from a patchwork of hardware appliances and point solutions, and instead consolidate security and networking through a unified control plane that includes products like [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/access-controls/policies/), [Secure Web Gateway (SWG)](https://developers.cloudflare.com/cloudflare-one/traffic-policies/), [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/), [Data Loss Prevention (DLP)](https://developers.cloudflare.com/cloudflare-one/data-loss-prevention/), [Remote Browser Isolation (RBI)](https://developers.cloudflare.com/cloudflare-one/remote-browser-isolation/), [Cloud Access Security Broker (CASB)](https://developers.cloudflare.com/cloudflare-one/integrations/cloud-and-saas/), and [Email security](https://developers.cloudflare.com/cloudflare-one/email-security/).
+
+Refer to our [SASE reference architecture](https://developers.cloudflare.com/reference-architecture/architectures/sase/) to learn how to plan, deploy, and manage SASE architecture with Cloudflare.
+
+[Get started](https://developers.cloudflare.com/cloudflare-one/setup/)
+
+[Zero Trust dashboard](https://one.dash.cloudflare.com/)
+
+[Implementation guides](https://developers.cloudflare.com/cloudflare-one/implementation-guides/)
+
+## Products
+
+**[Access](https://developers.cloudflare.com/cloudflare-one/access-controls/policies/)**
+
+Authenticate users accessing your applications, seamlessly onboard third-party users, and log every event and request.
+
+**[Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/)**
+
+Securely connect your resources to Cloudflare without exposing a public IP by using Cloudflare Tunnel, which establishes outbound-only connections from your infrastructure to Cloudflare’s global network via the lightweight `cloudflared` daemon.
+
+**[Secure Web Gateway (SWG)](https://developers.cloudflare.com/cloudflare-one/traffic-policies/)**
+
+Inspect and filter DNS, network, HTTP, and egress traffic to enforce your company's Acceptable Use Policy (UAP), block risky sites with custom blocklists and threat intelligence, and enhance visibility and protection across SaaS applications.
+
+**[WARP](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/warp/)**
+
+Protect corporate devices by privately sending traffic from those devices to Cloudflare's global network, build device posture rules, and enforce security policies anywhere.
+
+**[Browser Isolation (RBI)](https://developers.cloudflare.com/cloudflare-one/remote-browser-isolation/)**
+
+Mitigate the impact of attacks by executing all browser code in the cloud and securely browse high-risk or sensitive websites in a remote browser.
+
+**[Cloud Access Security Broker (CASB)](https://developers.cloudflare.com/cloudflare-one/integrations/cloud-and-saas/)**
+
+Protect users and sensitive data at rest in SaaS applications and cloud environments, scan for misconfigurations, and detect insider threats as well as unsanctioned application usage to prevent data leaks and compliance violations.
+
+**[Data Loss Prevention (DLP)](https://developers.cloudflare.com/cloudflare-one/data-loss-prevention/)**
+
+Scan your web traffic and SaaS applications for the presence of sensitive data such as social security numbers, financial information, secret keys, and source code.
+
+**[Email security](https://developers.cloudflare.com/cloudflare-one/email-security/)**
+
+Configure policies to manage your inbox, automatically move emails based on disposition, and use screen criteria to investigate messages.
+
+**[Digital Experience Monitoring (DEX)](https://developers.cloudflare.com/cloudflare-one/insights/dex/)**
+
+Monitor device, network, and application performance across your Zero Trust organization.
+
+***
+
+## More resources
+
+[SASE video series](https://developers.cloudflare.com/learning-paths/sase-overview-course/series/evolution-corporate-networks-1/)
+
+New to Zero Trust and SASE? Get started with our introductory SASE video series.
+
+[Reference architecture](https://developers.cloudflare.com/reference-architecture/architectures/sase/)
+
+Explore our reference architecture to learn how to evolve your network and security architecture to Cloudflare One, our SASE platform.
+
+[Plans](https://www.cloudflare.com/plans/zero-trust-services/)
+
+Cloudflare Zero Trust offers both Free and Paid plans. Access to certain features depends on a customer's plan type.
+
+[Limits](https://developers.cloudflare.com/cloudflare-one/account-limits/)
+
+Learn about account limits. These limits may be increased on Enterprise accounts.
+
+[Support](https://developers.cloudflare.com/support/contacting-cloudflare-support/)
+
+Find answers to common questions or open a ticket with Cloudflare Support.
+
+[Community](https://community.cloudflare.com/)
+
+Ask questions, get answers, and share tips.
+
+Note
+
+Enterprise customers can preview this product as a [non-contract service](https://developers.cloudflare.com/billing/preview-services/), which provides full access, free of metered usage fees, limits, and certain other restrictions.


### PR DESCRIPTION
## Summary
- add a Cloudflare Zero Trust overview document that captures the product lineup and reference links from the Cloudflare One docs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_69018782d668832e88eee4d4dc1681a2