### PR TITLE
Add Codex fraud canary playbook and governance scaffolding

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/codex-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/codex-checklist.md
@@ -1,0 +1,4 @@
+- [ ] Add `// codex:critical <path>` comments to files touching critical paths (if appropriate)
+- [ ] Added CODEOWNERS if new sensitive areas
+- [ ] Added tests (attribution/ML/fraud) or added canary in docs/codex/fixtures/
+- [ ] CI green: Codex Canary (fraud), Attribution QA, UI Snapshot (if frontend change)

--- a/.github/workflows/codex-fraud-canary.yml
+++ b/.github/workflows/codex-fraud-canary.yml
@@ -1,0 +1,47 @@
+name: Codex Fraud Canary
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  schedule:
+    - cron: "0 3 * * *"
+
+jobs:
+  fraud_canary:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install
+        run: npm ci
+      - name: Run Fraud Canary
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          FRAUD_API_KEY: ${{ secrets.FRAUD_API_KEY }}
+        run: |
+          node scripts/run-fraud-canary.js \
+            --supabase-url "$SUPABASE_URL" \
+            --supabase-key "$FRAUD_API_KEY" \
+            --pr "${{ github.event.number || '' }}" \
+            --fixtures "docs/codex/fixtures/fraud_canary/sample_campaigns.json"
+      - name: Generate Fraud Report
+        if: always()
+        run: |
+          node scripts/format-fraud-report.js --input fraud_summary.json --output reports/fraud-report.md
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fraud-report
+          path: reports/fraud-report.md
+      - name: Post PR Comment
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.number }}
+          body: |
+            $(cat reports/fraud-report.md)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,7 @@
+# Ownership for critical subsystems
+/src/lib/fraud-detection* @analytics-team
+/supabase/functions/fraud-detection* @analytics-team
+/src/lib/attribution* @data-team
+/supabase/functions/performance-prediction* @ml-team
+/src/components/AnalyticsDashboard* @frontend-team
+/docs/codex/* @brandonlacoste9-tech

--- a/docs/codex/README.md
+++ b/docs/codex/README.md
@@ -1,0 +1,32 @@
+# Codex Playbooks
+
+Codex playbooks are automation rituals that exercise critical subsystems end to end. Each playbook includes:
+
+- **Triggering context** (PR filters or schedules)
+- **Inputs and secrets** required to run
+- **Steps** that invoke Supabase functions or local engines via documented scripts
+- **Outputs** for CodexReplay overlays and stakeholder summaries
+
+## Running Fraud Canary locally
+
+```bash
+npm ci
+node scripts/run-fraud-canary.js \
+  --supabase-url "$SUPABASE_URL" \
+  --supabase-key "$FRAUD_API_KEY" \
+  --fixtures docs/codex/fixtures/fraud_canary/sample_campaigns.json
+node scripts/format-fraud-report.js --input fraud_summary.json --output reports/fraud-report.md
+```
+
+The scripts call the deployed Supabase function at `supabase/functions/fraud-detection-api` to ensure the same behavior observed in production. Reports land in `reports/fraud-report.md` and can be attached to PRs or incidents.
+
+## Secrets
+
+Add the following repository secrets before enabling the GitHub Action:
+
+- `SUPABASE_URL`
+- `FRAUD_API_KEY`
+
+## Additional playbooks
+
+Additional playbooks (Attribution QA, ML Drift, UI Snapshot Tour, Pricing Linter, Content Autopilot, Analytics Sanity) follow the same structure. Add new YAML definitions to `docs/codex/playbooks/` and pair them with scripts under `scripts/` plus workflows under `.github/workflows/`.

--- a/docs/codex/fixtures/fraud_canary/sample_campaigns.json
+++ b/docs/codex/fixtures/fraud_canary/sample_campaigns.json
@@ -1,0 +1,26 @@
+{
+  "campaigns": [
+    {
+      "id": "cmp-demo-001",
+      "name": "Demo Prospecting Burst",
+      "budget": 1250,
+      "geos": ["US", "CA"],
+      "channels": ["meta", "tiktok"],
+      "targeting": {
+        "interests": ["sustainability", "d2c"],
+        "age_range": [24, 45]
+      }
+    },
+    {
+      "id": "cmp-demo-002",
+      "name": "Retention Loyalty Push",
+      "budget": 800,
+      "geos": ["US"],
+      "channels": ["google_search"],
+      "targeting": {
+        "keywords": ["brand", "coupon"],
+        "audiences": ["purchasers_90d"]
+      }
+    }
+  ]
+}

--- a/docs/codex/playbooks/fraud_canary.yaml
+++ b/docs/codex/playbooks/fraud_canary.yaml
@@ -1,0 +1,45 @@
+playbook: fraud_canary
+name: "Fraud Canary - Codex Playbook"
+description: >
+  Run deterministic fraud checks for a PR or nightly job. Calls
+  Supabase fraud API, runs internal engine, compares to baseline,
+  emits summary, and files PR comment or issue when thresholds exceed.
+version: 1
+triggers:
+  - type: pull_request
+    conditions:
+      - changed_files_match: ["src/**", "supabase/functions/fraud-detection*"]
+  - type: schedule
+    cron: "0 3 * * *"   # nightly 03:00 UTC
+inputs:
+  - FRAUD_API_KEY (secret)
+  - SUPABASE_URL (secret)
+  - PR_NUMBER (int)
+  - CAMPAIGN_FIXTURES:
+      default: "docs/codex/fixtures/fraud_canary/sample_campaigns.json"
+env:
+  - NODE_ENV: "ci"
+  - CODEx_REASONING_LEVEL: "medium"
+steps:
+  - name: checkout
+    run: actions/checkout
+  - name: install
+    run: |
+      npm ci
+  - name: run-fraud-canary
+    run: |
+      node scripts/run-fraud-canary.js \
+        --supabase-url "${SUPABASE_URL}" \
+        --supabase-key "${FRAUD_API_KEY}" \
+        --pr "${PR_NUMBER}" \
+        --fixtures "${CAMPAIGN_FIXTURES}"
+    capture: fraud_summary.json
+  - name: generate-report
+    run: |
+      node scripts/format-fraud-report.js --input fraud_summary.json --output reports/fraud-report.md
+  - name: publish-report
+    run: |
+      ./scripts/publish-pr-comment-or-issue.sh reports/fraud-report.md
+outputs:
+  - report_path: reports/fraud-report.md
+  - severity: "low|medium|high|critical"

--- a/docs/codex/playbooks/short_recipes.md
+++ b/docs/codex/playbooks/short_recipes.md
@@ -1,0 +1,38 @@
+# Codex Playbook Recipes
+
+## Attribution QA
+- **Purpose:** Run the advanced attribution engine over canonical fixtures and compare models (first/last/linear/time-decay/Shapley/Markov).
+- **Hooks:** `src/lib/attribution-engine-advanced.js`, `supabase/functions/attribution-analytics-api`.
+- **Trigger:** PRs touching attribution code or weekly schedule.
+- **Workflow:** Load ~50 journeys → run `AdvancedAttributionEngine` models → generate CSV/markdown deltas → alert when shifts >5% for top channels.
+- **Output:** `reports/attribution-comparison-YYYYMMDD.md`.
+
+## ML Prediction Drift (Nightly)
+- **Purpose:** Evaluate `performance-prediction`/`ml-performance-api` using a holdout dataset and detect drift (AUC drop >2%, CTR mean shift >10%).
+- **Hooks:** `supabase/functions/performance-prediction/index.ts`, `supabase/functions/ml-performance-api`.
+- **Trigger:** Nightly schedule.
+- **Workflow:** Pull holdout from `docs/codex/fixtures/holdout.json` → invoke prediction endpoints → compare to baseline → create `codex:ml-drift` issue on anomaly.
+
+## UI Snapshot Tour (Analytics Surfaces)
+- **Purpose:** Playwright snapshots for `AnalyticsDashboard`, `EnhancedDashboard`, `ComparisonAnalytics` to catch DOM/metric drift.
+- **Hooks:** `src/components/AnalyticsDashboard.tsx`, `src/components/EnhancedDashboard.tsx`, `src/components/ComparisonAnalytics.tsx`.
+- **Trigger:** Frontend PRs or nightly.
+- **Workflow:** Launch Playwright, visit `/analytics`, `/comparison/:id`, `/enhanced` → capture widget snapshots → compare hashes → fail CI if critical elements disappear or breach thresholds.
+
+## Pricing & Plan Consistency Linter
+- **Purpose:** Assert rendered pricing aligns with canonical config.
+- **Hooks:** `src/components/SubscriptionStatus.*`, `lib/stripe`, `configs/pricing.json` (source of truth).
+- **Trigger:** Pricing-related PRs or nightly.
+- **Workflow:** Render pricing page headlessly → extract price strings → compare to config → post PR comment and optional auto-fix.
+
+## Content Engine Autopilot
+- **Purpose:** Batch-generate autopsies/case studies using `cms-automation-api` and `CMSEngine`.
+- **Hooks:** `src/lib/cms-engine-advanced.ts`, `supabase/functions/cms-automation-api`.
+- **Trigger:** Manual `workflow_dispatch` or monthly cadence.
+- **Workflow:** Feed campaign CSV → generate drafts → save to Supabase as drafts → open PR for `content/drafts/*.md` or create Linear issues.
+
+## Analytics Sanity Scripts
+- **Purpose:** Monitor AI performance scores vs revenue, fraud shield transitions, and missing metrics.
+- **Hooks:** `src/components/ComparisonAnalytics.tsx` metrics exports.
+- **Trigger:** Nightly.
+- **Workflow:** Evaluate telemetry snapshots → flag score spikes without revenue, fraud shield `critical`, or missing metrics → file actionable issues with logs.

--- a/package.json
+++ b/package.json
@@ -7,13 +7,16 @@
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "dev": "netlify dev",
-    "deploy": "netlify deploy --prod"
+    "deploy": "netlify deploy --prod",
+    "codex:fraud-canary": "node scripts/run-fraud-canary.js --fixtures docs/codex/fixtures/fraud_canary/sample_campaigns.json"
   },
   "dependencies": {
     "@netlify/functions": "^2.4.0",
     "@netlify/blobs": "^7.0.0",
     "zod": "^3.22.4",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "minimist": "^1.2.8",
+    "node-fetch": "^3.3.2"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",

--- a/scripts/format-fraud-report.js
+++ b/scripts/format-fraud-report.js
@@ -1,0 +1,60 @@
+import fs from 'fs';
+import path from 'path';
+import minimist from 'minimist';
+
+const argv = minimist(process.argv.slice(2));
+const inputPath = argv.input;
+const outputPath = argv.output || 'reports/fraud-report.md';
+
+if (!inputPath) {
+  console.error('Missing --input path for fraud summary');
+  process.exit(1);
+}
+
+const summary = JSON.parse(fs.readFileSync(inputPath, 'utf8'));
+const { pr = '', timestamp, results = [] } = summary;
+
+const rows = results.map(({ campaignId, analysis }) => {
+  const risk = analysis?.riskLevel ?? 'unknown';
+  const score = analysis?.fraud_score ?? analysis?.score ?? 'n/a';
+  return `| ${campaignId} | ${score} | ${risk} |`;
+});
+
+const signalSections = results.map(({ campaignId, analysis }) => {
+  if (!Array.isArray(analysis?.signals) || !analysis.signals.length) {
+    return `- ${campaignId}: No detailed signals provided.`;
+  }
+  const bullets = analysis.signals.slice(0, 5).map(signal => `  - ${signal}`).join('\n');
+  return `- ${campaignId}:\n${bullets}`;
+});
+
+const reportLines = [
+  '# Codex Fraud Canary Report',
+  '',
+  `- Generated: ${timestamp || new Date().toISOString()}`,
+  pr ? `- PR: ${pr}` : '- PR: (scheduled run)',
+  '',
+  '| Campaign | Fraud Score | Risk Level |',
+  '| --- | --- | --- |',
+  ...rows,
+  '',
+  '## Signals',
+  '',
+  ...signalSections,
+  '',
+  '## Recommended Actions',
+  '',
+  results.length
+    ? '- Review high-risk campaigns and apply `// codex:hold` annotations as needed.'
+    : '- No campaigns evaluated. Confirm fixtures are configured.',
+  '- Investigate signals flagged in Supabase logs for deeper insight.',
+  '',
+  '## Telemetry Attachments',
+  '',
+  '- Source summary: `fraud_summary.json`',
+  '- Supabase function: `supabase/functions/fraud-detection-api`'
+];
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, reportLines.join('\n'));
+console.log(`Fraud report written to ${outputPath}`);

--- a/scripts/publish-pr-comment-or-issue.sh
+++ b/scripts/publish-pr-comment-or-issue.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPORT_PATH=${1:-reports/fraud-report.md}
+
+if [[ ! -f "$REPORT_PATH" ]]; then
+  echo "Report path $REPORT_PATH not found" >&2
+  exit 1
+fi
+
+if [[ -n "${GITHUB_EVENT_NAME:-}" && "${GITHUB_EVENT_NAME}" == pull_request* ]]; then
+  gh pr comment "${GITHUB_REF_NAME:-}" --body-file "$REPORT_PATH"
+else
+  gh issue create --title "Codex Fraud Canary Alert" --body-file "$REPORT_PATH" --label "codex:fraud"
+fi

--- a/scripts/run-fraud-canary.js
+++ b/scripts/run-fraud-canary.js
@@ -1,0 +1,51 @@
+import fs from 'fs';
+import fetch from 'node-fetch';
+import minimist from 'minimist';
+
+const argv = minimist(process.argv.slice(2));
+const SUPABASE_URL = argv['supabase-url'] || process.env.SUPABASE_URL;
+const SUPABASE_KEY = argv['supabase-key'] || process.env.FRAUD_API_KEY;
+const PR = argv.pr || process.env.PR_NUMBER || process.env.GITHUB_REF || '';
+const FIXTURES = argv.fixtures || 'docs/codex/fixtures/fraud_canary/sample_campaigns.json';
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing SUPABASE_URL or FRAUD_API_KEY');
+  process.exit(1);
+}
+
+async function callSupabaseFunction(campaign) {
+  const response = await fetch(`${SUPABASE_URL}/functions/v1/fraud-detection-api`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${SUPABASE_KEY}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ campaign })
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Supabase function returned ${response.status}: ${text}`);
+  }
+
+  return response.json();
+}
+
+async function run() {
+  const fixtures = JSON.parse(fs.readFileSync(FIXTURES, 'utf8'));
+  const results = [];
+
+  for (const campaign of fixtures.campaigns || []) {
+    const analysis = await callSupabaseFunction(campaign);
+    results.push({ campaignId: campaign.id, analysis });
+  }
+
+  const payload = { pr: PR, timestamp: new Date().toISOString(), results };
+  fs.writeFileSync('fraud_summary.json', JSON.stringify(payload, null, 2));
+  console.log('fraud_summary.json written');
+}
+
+run().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add Codex Fraud Canary playbook definition, fixtures, and supporting scripts
- wire a GitHub Action workflow and npm alias to execute the canary against Supabase fraud APIs
- document Codex playbook usage and codify CODEOWNERS plus PR checklist governance

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_6901813fb870832e829bebf93522bdae