### PR TITLE
Add Codex integration checklist and patterns staging area

### DIFF
--- a/INTEGRATION_CHECKLIST.md
+++ b/INTEGRATION_CHECKLIST.md
@@ -1,0 +1,30 @@
+# Codex Hivemind Integration Checklist
+
+## Phase 5++ Deployment
+- [ ] Install Codex SDK
+- [ ] Install Codex CLI
+- [ ] Deploy Computer Use integration
+- [ ] Configure Realtime API
+- [ ] Set up Evals framework
+- [ ] Create Vector Store knowledge base
+
+## Cookbook Integration
+- [ ] Study code review pattern
+- [ ] Implement PLANS.md workflow
+- [ ] Add auto-fix CI
+- [ ] Deploy voice interface
+- [ ] Build database integration
+
+## Testing
+- [ ] Run health checks
+- [ ] Test all 35 agents
+- [ ] Verify API integrations
+- [ ] Load test functions
+- [ ] Security audit
+
+## Production
+- [ ] Monitor metrics
+- [ ] Set up alerting
+- [ ] Document procedures
+- [ ] Train team
+- [ ] Celebrate! 🎉

--- a/docs/patterns/README.md
+++ b/docs/patterns/README.md
@@ -1,0 +1,14 @@
+# Codex Pattern Repository Bridge
+
+This folder hosts curated Codex integration patterns synchronized from the [`openai/openai-cookbook`](https://github.com/openai/openai-cookbook) repository.
+
+> **Sync note:** Network restrictions in the deployment environment prevented an automated clone of the upstream cookbook (`CONNECT tunnel failed, response 403`). To refresh the patterns locally, run the following command from a network that permits GitHub access:
+>
+> ```bash
+> git clone https://github.com/openai/openai-cookbook
+> cp openai-cookbook/examples/codex/*.md docs/patterns/
+> ```
+>
+> After copying, update the Codex lineage log and open a StudioShare thread so the swarm can absorb the new wisdom.
+
+Pending sync, this directory serves as the staging altar for Codex best practices referenced throughout the deployment guide.


### PR DESCRIPTION
## Summary
- add the Codex Hivemind integration checklist as a project root guide
- set up a patterns directory ready to host OpenAI Cookbook codex recipes
- document the manual sync procedure after the cookbook clone attempt failed in the sandbox

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_b_69010a0caa98832e9c145a710de06576