### PR TITLE
Add GitHub PR triage reporting script

### DIFF
--- a/docs/pr-triage.md
+++ b/docs/pr-triage.md
@@ -1,0 +1,53 @@
+# Pull Request Triage Workflow
+
+The triage ritual helps us keep the swarm focused on active, high-signal pull requests. Use the `triage:prs` npm script to assemble a snapshot of every open PR and the recommended follow-up action.
+
+```bash
+npm run triage:prs -- --repo owner/repo --output reports/pr-triage.md
+```
+
+## Inputs
+
+- `--repo` (**required**): the GitHub slug (for example `adgenxai/core`). Defaults to the `GITHUB_REPOSITORY` environment variable if set.
+- `--token`: GitHub token used to raise the rate limit ceiling. Falls back to `GITHUB_TOKEN`.
+- `--stale-days`: Overrides the 90 day stale threshold.
+- `--inactive-days`: Overrides the 30 day "needs author nudge" threshold.
+- `--recent-days`: Reserved for future heuristics. Defaults to 14.
+- `--output`: Path for the generated Markdown report. Parent folders will be created as needed.
+
+> [!NOTE]
+> Without a token the script still works for public repositories, but GitHub will enforce a lower rate limit.
+
+## Output
+
+The generated Markdown contains:
+
+- A summary table that counts PRs per triage bucket.
+- A detailed table with CI status, review signals, timestamps, and the recommended action.
+- Suggested actions:
+  - `queue-for-merge`
+  - `request-review`
+  - `wait-for-ci`
+  - `request-fix`
+  - `confirm-status`
+  - `comment-to-close`
+  - `manual-review`
+
+The checklist is intentionally reversible—comment before closing or merging.
+
+## Operational Notes
+
+- The script uses GitHub's REST API (`pulls`, `reviews`, and `commits/status`) to minimize surprises.
+- Each reviewer only counts once—their latest review decision wins.
+- WIP signals are inferred from draft status or labels containing `wip`.
+- Reports are timestamped so they can be attached to CodexReplay overlays or StudioShare threads.
+
+## Example
+
+Running against this repository with an authenticated token:
+
+```bash
+GITHUB_TOKEN=ghp_example npm run triage:prs -- --repo adgenxai/adgenxai --output reports/pr-triage-$(date +%Y%m%d).md
+```
+
+You'll see the rendered Markdown in the console and written to the `reports/` directory. Attach the artifact to the swarm changelog so future keepers can trace the lineage.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "deploy": "netlify deploy --prod",
     "test": "vitest run --reporter=dot",
     "test:watch": "vitest",
-    "test:ci": "vitest run --coverage --reporter=dot"
+    "test:ci": "vitest run --coverage --reporter=dot",
+    "triage:prs": "node scripts/pr-triage.mjs"
   },
   "dependencies": {
     "@netlify/blobs": "^7.0.0",

--- a/scripts/pr-triage.mjs
+++ b/scripts/pr-triage.mjs
@@ -1,0 +1,397 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+const ISO_FORMATTER = new Intl.DateTimeFormat('en-CA', {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
+const DEFAULT_CONFIG = {
+  staleDays: 90,
+  inactiveDays: 30,
+  recentDays: 14,
+};
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg.startsWith('--')) {
+      const [key, value] = arg.split('=');
+      const normalizedKey = key.replace(/^--/, '');
+      if (value !== undefined) {
+        args[normalizedKey] = value;
+      } else {
+        const next = argv[i + 1];
+        if (next && !next.startsWith('--')) {
+          args[normalizedKey] = next;
+          i += 1;
+        } else {
+          args[normalizedKey] = true;
+        }
+      }
+    }
+  }
+  return args;
+}
+
+function env(name, fallback) {
+  return process.env[name] ?? fallback;
+}
+
+function toISODate(input) {
+  return ISO_FORMATTER.format(new Date(input));
+}
+
+function toDaysSince(input) {
+  const diff = Date.now() - new Date(input).getTime();
+  return Math.floor(diff / (1000 * 60 * 60 * 24));
+}
+
+async function githubRequest(url, token, options = {}) {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      'User-Agent': 'adgenxai-pr-triage-script',
+      Accept: 'application/vnd.github+json',
+      Authorization: token ? `Bearer ${token}` : undefined,
+      ...options.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`GitHub request failed (${response.status} ${response.statusText}) for ${url}: ${text}`);
+  }
+
+  return response.json();
+}
+
+async function fetchAllPulls(repo, token) {
+  const pulls = [];
+  let page = 1;
+  const perPage = 100;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const url = `https://api.github.com/repos/${repo}/pulls?state=open&per_page=${perPage}&page=${page}`;
+    const pageData = await githubRequest(url, token);
+    if (!Array.isArray(pageData) || pageData.length === 0) {
+      break;
+    }
+    pulls.push(...pageData);
+    if (pageData.length < perPage) {
+      break;
+    }
+    page += 1;
+  }
+
+  return pulls;
+}
+
+function summarizeChecks(statusResponse) {
+  if (!statusResponse || typeof statusResponse !== 'object') {
+    return { state: 'unknown', description: 'No status information' };
+  }
+
+  const { state, statuses = [] } = statusResponse;
+  const description = statuses
+    .map((status) => `${status.context}: ${status.state}`)
+    .join('; ');
+
+  return { state: state ?? 'unknown', description: description || 'No checks reported' };
+}
+
+function summarizeReviews(reviews) {
+  if (!Array.isArray(reviews) || reviews.length === 0) {
+    return { approved: false, changesRequested: false };
+  }
+
+  const latestReviewByUser = new Map();
+  for (const review of reviews) {
+    latestReviewByUser.set(review.user?.login ?? 'unknown', review.state);
+  }
+
+  let approved = false;
+  let changesRequested = false;
+  for (const state of latestReviewByUser.values()) {
+    if (state === 'APPROVED') {
+      approved = true;
+    }
+    if (state === 'CHANGES_REQUESTED') {
+      changesRequested = true;
+    }
+  }
+
+  return { approved, changesRequested };
+}
+
+function deriveCategory({
+  pr,
+  checks,
+  reviewSummary,
+  config,
+}) {
+  const daysOpen = toDaysSince(pr.created_at);
+  const daysSinceUpdate = toDaysSince(pr.updated_at);
+  const wipLabel = pr.labels?.some((label) => /wip|work in progress/i.test(label.name ?? ''));
+
+  if (daysSinceUpdate >= config.staleDays) {
+    return {
+      category: 'stale',
+      action: 'comment-to-close',
+      rationale: `No updates for ${daysSinceUpdate} days (opened ${daysOpen} days ago).`,
+    };
+  }
+
+  if (pr.draft || wipLabel) {
+    return {
+      category: 'work-in-progress',
+      action: 'confirm-status',
+      rationale: pr.draft ? 'Draft PR.' : 'Marked with WIP label.',
+    };
+  }
+
+  if (checks.state === 'success' && reviewSummary.approved) {
+    return {
+      category: 'ready-to-merge',
+      action: 'queue-for-merge',
+      rationale: 'CI green with approval.',
+    };
+  }
+
+  if (checks.state === 'success') {
+    return {
+      category: 'needs-review',
+      action: 'request-review',
+      rationale: 'CI passed but no approval recorded.',
+    };
+  }
+
+  if (checks.state === 'pending') {
+    return {
+      category: 'pending-checks',
+      action: 'wait-for-ci',
+      rationale: 'CI checks still running.',
+    };
+  }
+
+  if (checks.state === 'failure') {
+    const inactiveReason = daysSinceUpdate >= config.inactiveDays
+      ? `CI failing and no updates for ${daysSinceUpdate} days.`
+      : 'CI failing.';
+    return {
+      category: 'needs-author-action',
+      action: 'request-fix',
+      rationale: inactiveReason,
+    };
+  }
+
+  return {
+    category: 'uncategorized',
+    action: 'manual-review',
+    rationale: 'Unable to determine state from CI and reviews.',
+  };
+}
+
+async function collectDetails(repo, token, config) {
+  const pulls = await fetchAllPulls(repo, token);
+  const records = [];
+
+  for (const pr of pulls) {
+    const [statusResponse, reviews] = await Promise.all([
+      githubRequest(`https://api.github.com/repos/${repo}/commits/${pr.head.sha}/status`, token),
+      githubRequest(`https://api.github.com/repos/${repo}/pulls/${pr.number}/reviews`, token),
+    ]);
+
+    const checks = summarizeChecks(statusResponse);
+    const reviewSummary = summarizeReviews(reviews);
+    const { category, action, rationale } = deriveCategory({ pr, checks, reviewSummary, config });
+
+    records.push({
+      number: pr.number,
+      title: pr.title,
+      url: pr.html_url,
+      author: pr.user?.login ?? 'unknown',
+      createdAt: pr.created_at,
+      updatedAt: pr.updated_at,
+      draft: pr.draft,
+      labels: (pr.labels || []).map((label) => label.name).join(', '),
+      checks,
+      reviewSummary,
+      category,
+      action,
+      rationale,
+    });
+  }
+
+  return records;
+}
+
+function renderSummary(records) {
+  const counts = records.reduce((acc, record) => {
+    acc[record.category] = (acc[record.category] || 0) + 1;
+    return acc;
+  }, {});
+
+  const entries = Object.entries(counts)
+    .sort(([, a], [, b]) => b - a)
+    .map(([category, count]) => `| ${category} | ${count} |`)
+    .join('\n');
+
+  return ['| Category | Count |', '| --- | ---: |', entries || '| (none) | 0 |'].join('\n');
+}
+
+function renderMetadata({ jobId, generatedAt, totalPRs, categories, sizeBytes }) {
+  const rows = [
+    '| key | value |',
+    '| --- | --- |',
+    `| jobId | ${jobId} |`,
+    `| generatedAt | ${generatedAt} |`,
+    `| totalPRs | ${totalPRs} |`,
+    `| categories | ${categories.length ? categories.join(', ') : '(none)'} |`,
+  ];
+
+  if (typeof sizeBytes === 'number') {
+    rows.push(`| sizeBytes | ${sizeBytes} |`);
+  }
+
+  return rows.join('\n');
+}
+
+function renderReport({ repo, generatedAt, metadataTable, summaryTable, detailsTable }) {
+  return [
+    `# Pull Request Triage Report for ${repo}`,
+    '',
+    `Generated: ${generatedAt}`,
+    '',
+    '## Operational Metadata',
+    metadataTable,
+    '',
+    '## Summary',
+    summaryTable,
+    '',
+    '## Details',
+    detailsTable,
+    '',
+    '> Report generated by `npm run triage:prs`.',
+    '',
+  ].join('\n');
+}
+
+function renderDetails(records) {
+  const header = [
+    '| PR | Author | Created | Updated | Draft | CI | Reviews | Category | Action | Rationale |',
+    '| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |',
+  ];
+
+  const rows = records
+    .sort((a, b) => a.number - b.number)
+    .map((record) => {
+      const created = `${toISODate(record.createdAt)} (${toDaysSince(record.createdAt)}d)`;
+      const updated = `${toISODate(record.updatedAt)} (${toDaysSince(record.updatedAt)}d)`;
+      const ci = `${record.checks.state}${record.checks.description ? ` — ${record.checks.description}` : ''}`;
+      const reviews = record.reviewSummary.approved
+        ? 'approved'
+        : record.reviewSummary.changesRequested
+          ? 'changes requested'
+          : 'none';
+      const draft = record.draft ? 'yes' : 'no';
+      const title = record.title.replace(/\|/g, '\\|');
+
+      return `| [#${record.number}](${record.url}) ${title} | ${record.author} | ${created} | ${updated} | ${draft} | ${ci} | ${reviews} | ${record.category} | ${record.action} | ${record.rationale.replace(/\|/g, '\\|')} |`;
+    });
+
+  return header.concat(rows).join('\n');
+}
+
+async function writeOutput(records, outputPath, repo, jobId) {
+  const generatedAt = new Date().toISOString();
+  const summaryTable = renderSummary(records);
+  const detailsTable = renderDetails(records);
+  const categories = Array.from(new Set(records.map((record) => record.category))).sort();
+
+  let metadataTable = renderMetadata({
+    jobId,
+    generatedAt,
+    totalPRs: records.length,
+    categories,
+  });
+
+  let content = renderReport({
+    repo,
+    generatedAt,
+    metadataTable,
+    summaryTable,
+    detailsTable,
+  });
+
+  const sizeBytes = Buffer.byteLength(content, 'utf8');
+  metadataTable = renderMetadata({
+    jobId,
+    generatedAt,
+    totalPRs: records.length,
+    categories,
+    sizeBytes,
+  });
+
+  content = renderReport({
+    repo,
+    generatedAt,
+    metadataTable,
+    summaryTable,
+    detailsTable,
+  });
+
+  if (outputPath) {
+    const resolved = path.resolve(outputPath);
+    await fs.mkdir(path.dirname(resolved), { recursive: true });
+    await fs.writeFile(resolved, content, 'utf8');
+    return { outputPath: resolved, content, sizeBytes };
+  }
+
+  return { outputPath: null, content, sizeBytes };
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const repo = args.repo || env('GITHUB_REPOSITORY');
+
+  if (!repo) {
+    console.error('Repository must be provided via --repo or GITHUB_REPOSITORY.');
+    process.exit(1);
+  }
+
+  const token = args.token || env('GITHUB_TOKEN');
+  if (!token) {
+    console.warn('⚠️  No GitHub token provided. You may be rate limited for public repositories.');
+  }
+
+  const config = {
+    staleDays: args['stale-days'] ? Number(args['stale-days']) : DEFAULT_CONFIG.staleDays,
+    inactiveDays: args['inactive-days'] ? Number(args['inactive-days']) : DEFAULT_CONFIG.inactiveDays,
+    recentDays: args['recent-days'] ? Number(args['recent-days']) : DEFAULT_CONFIG.recentDays,
+  };
+
+  try {
+    const records = await collectDetails(repo, token, config);
+    const jobId = args['job-id'] || crypto.randomUUID();
+    const { outputPath, content, sizeBytes } = await writeOutput(records, args.output, repo, jobId);
+
+    if (outputPath) {
+      console.log(`Triage report written to ${outputPath}`);
+    }
+
+    const categoryList = Array.from(new Set(records.map((record) => record.category))).sort().join(', ') || '(none)';
+    console.log(`[pr-triage-metadata] jobId=${jobId} totalPRs=${records.length} sizeBytes=${sizeBytes} categories=${categoryList}`);
+    console.log(content);
+  } catch (error) {
+    console.error(`Failed to generate triage report: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a Node-based triage command that gathers open pull request metadata and renders a markdown report
- log operational metadata for CodexReplay overlays while supporting configurable stale and inactivity thresholds
- document the triage workflow and wire the command into the npm scripts catalog

## Testing
- `npm run triage:prs -- --repo vercel/next.js --stale-days 1 --inactive-days 1 --recent-days 1 --output /tmp/triage.md` *(fails in the sandbox because outbound network access is blocked)*

------
https://chatgpt.com/codex/tasks/task_b_690839edc9c0832e964f590787192794