### PR TITLE
Improve automation tooling reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,6 +211,10 @@ __marimo__/
 .env.local
 .netlify/
 dist/
+!agents/github-pr-manager/
+!agents/github-pr-manager/dist/
+!agents/github-pr-manager/dist/index.js
+!agents/github-pr-manager/ecosystem.config.js
 node_modules/
 
 # OS

--- a/agents/github-pr-manager/dist/index.js
+++ b/agents/github-pr-manager/dist/index.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import http from 'node:http';
+import process from 'node:process';
+import { randomUUID } from 'node:crypto';
+
+const port = Number(process.env.PORT || 3001);
+const host = process.env.HOST || '0.0.0.0';
+const startedAt = new Date().toISOString();
+const jobId = randomUUID();
+
+const log = (message) => {
+  const entry = `[github-pr-manager] ${new Date().toISOString()} ${message}`;
+  process.stdout.write(`${entry}\n`);
+};
+
+const server = http.createServer((req, res) => {
+  if (!req.url) {
+    res.statusCode = 400;
+    res.end('Bad request');
+    return;
+  }
+
+  if (req.method === 'GET' && req.url.startsWith('/health')) {
+    const payload = JSON.stringify({
+      status: 'healthy',
+      startedAt,
+      port,
+      host,
+      jobId
+    });
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.setHeader('Content-Length', Buffer.byteLength(payload));
+    res.end(payload);
+    return;
+  }
+
+  res.statusCode = 404;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify({ status: 'not_found', path: req.url }));
+});
+
+server.on('error', (error) => {
+  log(`Server error: ${error.message}`);
+  process.exit(1);
+});
+
+server.listen(port, host, () => {
+  log(`Listening on http://${host}:${port} (jobId=${jobId})`);
+});
+
+const shutdown = () => {
+  log('Shutting down...');
+  server.close(() => {
+    log('Shutdown complete');
+    process.exit(0);
+  });
+};
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);

--- a/agents/github-pr-manager/ecosystem.config.js
+++ b/agents/github-pr-manager/ecosystem.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  apps: [
+    {
+      name: 'github-pr-manager',
+      script: 'dist/index.js',
+      cwd: __dirname,
+      interpreter: process.execPath,
+      env: {
+        PORT: process.env.PORT || 3001,
+        NODE_ENV: process.env.NODE_ENV || 'production'
+      },
+      kill_timeout: 3000,
+      restart_delay: 1000,
+      max_restarts: 5
+    }
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "dev": "netlify dev",
-    "deploy": "netlify deploy --prod"
+    "deploy": "netlify deploy --prod",
+    "triage:prs": "node scripts/pr-triage.mjs"
   },
   "dependencies": {
     "@netlify/functions": "^2.4.0",

--- a/pr-automation.ps1
+++ b/pr-automation.ps1
@@ -1,0 +1,158 @@
+[CmdletBinding()]
+param(
+    [Parameter()] [string] $Repo = "brandonlacoste9-tech/adgenxai",
+    [Parameter()] [ValidateSet("json", "markdown")] [string] $Format = "json",
+    [Parameter()] [string] $OutputPath = "artifacts/triage-report.json",
+    [Parameter()] [int] $Limit = 50,
+    [Parameter()] [switch] $DryRun,
+    [Parameter()] [switch] $Force,
+    [Parameter()] [string] $LogPath = "logs/pr-automation.log",
+    [Parameter()] [string] $GitHubApiBase = "https://api.github.com"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Initialize-Log {
+    param([string] $Path)
+    $directory = Split-Path -Path $Path -Parent
+    if (-not [string]::IsNullOrWhiteSpace($directory)) {
+        if (-not (Test-Path -Path $directory)) {
+            New-Item -ItemType Directory -Path $directory -Force | Out-Null
+        }
+    }
+    if (-not (Test-Path -Path $Path)) {
+        New-Item -ItemType File -Path $Path -Force | Out-Null
+    }
+}
+
+Initialize-Log -Path $LogPath
+
+function Write-Log {
+    param(
+        [string] $Message,
+        [string] $Level = "INFO"
+    )
+    $timestamp = (Get-Date).ToString("s")
+    $entry = "[$timestamp][$Level] $Message"
+    Add-Content -Path $LogPath -Value $entry
+}
+
+function Write-Status {
+    param(
+        [string] $Message,
+        [string] $Level = "Info"
+    )
+    $prefix = "[$Level]"
+    Write-Host "$prefix $Message"
+    Write-Log -Message "$prefix $Message" -Level $Level.ToUpperInvariant()
+}
+
+function Ensure-Token {
+    param([string] $ApiBase)
+    if (-not $env:GITHUB_TOKEN -or [string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN)) {
+        Write-Status "GITHUB_TOKEN not set in session. Set it with: $env:GITHUB_TOKEN = 'ghp_your_token'" "Error"
+        exit 1
+    }
+
+    $headers = @{ Authorization = "token $($env:GITHUB_TOKEN)"; "User-Agent" = "pr-automation" }
+
+    try {
+        $response = Invoke-RestMethod -Uri "$ApiBase/user" -Headers $headers -Method Get -TimeoutSec 8
+        if (-not $response.login) {
+            throw "GitHub API returned an unexpected payload."
+        }
+        Write-Status "Authenticated as $($response.login)" "Info"
+    }
+    catch {
+        Write-Status "GITHUB_TOKEN rejected by GitHub API: $($_.Exception.Message)" "Error"
+        exit 1
+    }
+}
+
+function Write-FileSafely {
+    param(
+        [string] $TargetPath,
+        [string] $Content
+    )
+    $directory = Split-Path -Path $TargetPath -Parent
+    if (-not [string]::IsNullOrWhiteSpace($directory)) {
+        if (-not (Test-Path -Path $directory)) {
+            New-Item -ItemType Directory -Path $directory -Force | Out-Null
+        }
+    }
+    $tempPath = [System.IO.Path]::GetTempFileName()
+    [System.IO.File]::WriteAllText($tempPath, $Content, [System.Text.Encoding]::UTF8)
+    Move-Item -Path $tempPath -Destination $TargetPath -Force
+}
+
+function Invoke-Process {
+    param(
+        [string] $FilePath,
+        [string[]] $Arguments,
+        [string] $Description,
+        [string] $WorkingDirectory = (Get-Location).Path
+    )
+
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $FilePath
+    $psi.WorkingDirectory = $WorkingDirectory
+    $psi.UseShellExecute = $false
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.CreateNoWindow = $true
+
+    foreach ($argument in $Arguments) {
+        $null = $psi.ArgumentList.Add($argument)
+    }
+
+    Write-Status "Starting $Description" "Info"
+    $process = [System.Diagnostics.Process]::Start($psi)
+    $stdout = $process.StandardOutput.ReadToEnd()
+    $stderr = $process.StandardError.ReadToEnd()
+    $process.WaitForExit()
+
+    if ($stderr) {
+        Write-Status "$Description stderr: $stderr" "Warning"
+    }
+
+    if ($process.ExitCode -ne 0) {
+        Write-Status "$Description failed with exit code $($process.ExitCode)" "Error"
+        throw "$Description failed"
+    }
+
+    Write-Status "$Description completed" "Info"
+    return [PSCustomObject]@{ StdOut = $stdout; StdErr = $stderr; ExitCode = $process.ExitCode }
+}
+
+try {
+    Ensure-Token -ApiBase $GitHubApiBase
+
+    $isInteractive = $Host.Name -ne "ServerRemoteHost" -and $Host.UI -and $Host.UI.RawUI
+    if (-not $Force -and $isInteractive -and -not $DryRun) {
+        $answer = Read-Host "Proceed with automation steps? Type YES to continue"
+        if ($answer.ToUpperInvariant() -ne "YES") {
+            Write-Status "Automation cancelled by user" "Warning"
+            exit 0
+        }
+    }
+
+    $arguments = @("run", "triage:prs", "--", "--repo", $Repo, "--format", $Format, "--limit", $Limit.ToString(), "--output", "-")
+    if ($DryRun) {
+        $arguments += "--dry-run"
+    }
+    if ($Force) {
+        $arguments += "--force"
+    }
+
+    $result = Invoke-Process -FilePath "npm" -Arguments $arguments -Description "npm triage pipeline"
+
+    Write-FileSafely -TargetPath $OutputPath -Content $result.StdOut
+    Write-Status "Report written to $OutputPath" "Info"
+}
+catch {
+    Write-Status "Automation failed: $($_.Exception.Message)" "Error"
+    exit 1
+}
+finally {
+    Write-Status "Automation script finished" "Info"
+}

--- a/scripts/pr-triage.mjs
+++ b/scripts/pr-triage.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+import { mkdir, writeFile, rename, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname, isAbsolute, resolve } from 'node:path';
+import process from 'node:process';
+import { randomUUID } from 'node:crypto';
+
+const exitWith = (code, message) => {
+  if (message) {
+    process.stderr.write(`${message}\n`);
+  }
+  process.exit(code);
+};
+
+const parseArgs = (argv) => {
+  const options = {
+    repo: '',
+    format: 'json',
+    limit: 20,
+    output: '-',
+    dryRun: false,
+    force: false
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    switch (token) {
+      case '--repo':
+        options.repo = argv[++i] ?? '';
+        break;
+      case '--format':
+        options.format = (argv[++i] ?? 'json').toLowerCase();
+        break;
+      case '--limit':
+        options.limit = Number(argv[++i] ?? '20');
+        break;
+      case '--output':
+        options.output = argv[++i] ?? '-';
+        break;
+      case '--dry-run':
+        options.dryRun = true;
+        break;
+      case '--force':
+        options.force = true;
+        break;
+      default:
+        exitWith(1, `Unknown argument: ${token}`);
+    }
+  }
+
+  if (!options.repo) {
+    exitWith(1, 'Missing required --repo option.');
+  }
+
+  if (!['json', 'markdown'].includes(options.format)) {
+    exitWith(1, 'Unsupported format. Use json or markdown.');
+  }
+
+  if (!Number.isFinite(options.limit) || options.limit <= 0) {
+    exitWith(1, '--limit must be a positive number.');
+  }
+
+  return options;
+};
+
+const run = async () => {
+  const options = parseArgs(process.argv.slice(2));
+  const token = process.env.GITHUB_TOKEN;
+  const apiBase = process.env.GITHUB_API_BASE || 'https://api.github.com';
+
+  if (!token || token.trim() === '') {
+    exitWith(1, 'GITHUB_TOKEN not set. Export a valid token before running triage.');
+  }
+
+  const headers = {
+    Authorization: `token ${token}`,
+    'User-Agent': 'pr-triage-cli',
+    Accept: 'application/vnd.github+json'
+  };
+
+  const validateResponse = await fetch(`${apiBase}/user`, { headers, method: 'GET' });
+  if (!validateResponse.ok) {
+    const body = await validateResponse.text();
+    exitWith(1, `GitHub token validation failed (${validateResponse.status}): ${body}`);
+  }
+
+  const pullsResponse = await fetch(`${apiBase}/repos/${options.repo}/pulls?state=open&per_page=${options.limit}`, {
+    headers,
+    method: 'GET'
+  });
+
+  if (!pullsResponse.ok) {
+    const body = await pullsResponse.text();
+    exitWith(1, `Failed to query pull requests (${pullsResponse.status}): ${body}`);
+  }
+
+  const pulls = await pullsResponse.json();
+  const generatedAt = new Date().toISOString();
+  const baseReport = {
+    repo: options.repo,
+    generatedAt,
+    dryRun: options.dryRun,
+    limit: options.limit,
+    pullRequests: pulls.map((pull) => ({
+      number: pull.number,
+      title: pull.title,
+      author: pull.user?.login ?? 'unknown',
+      url: pull.html_url,
+      draft: Boolean(pull.draft),
+      createdAt: pull.created_at,
+      mergeableState: pull.mergeable_state ?? 'unknown'
+    }))
+  };
+
+  const formatAsMarkdown = (report) => {
+    const lines = [];
+    lines.push(`# Pull request triage for ${report.repo}`);
+    lines.push(`Generated at ${report.generatedAt}`);
+    lines.push('');
+    if (report.pullRequests.length === 0) {
+      lines.push('No open pull requests found.');
+      return lines.join('\n');
+    }
+    lines.push('| Number | Title | Author | Draft | Created |');
+    lines.push('| --- | --- | --- | --- | --- |');
+    for (const item of report.pullRequests) {
+      lines.push(`| #${item.number} | ${item.title.replace(/\|/g, '\\|')} | ${item.author} | ${item.draft ? 'yes' : 'no'} | ${item.createdAt} |`);
+    }
+    return lines.join('\n');
+  };
+
+  let payload;
+  if (options.format === 'markdown') {
+    payload = formatAsMarkdown(baseReport);
+  } else {
+    payload = JSON.stringify(baseReport, null, 2);
+  }
+
+  const writeOutput = async (content) => {
+    if (options.output === '-') {
+      process.stdout.write(`${content}\n`);
+      return;
+    }
+
+    const absoluteOutput = isAbsolute(options.output)
+      ? options.output
+      : resolve(process.cwd(), options.output);
+    const directory = dirname(absoluteOutput);
+    await mkdir(directory, { recursive: true });
+
+    const tempDirectory = directory || process.cwd();
+    const tempFile = join(tempDirectory === '' ? tmpdir() : tempDirectory, `.triage-${randomUUID()}.tmp`);
+    await writeFile(tempFile, content, { encoding: 'utf8' });
+    await rm(absoluteOutput, { force: true });
+    await rename(tempFile, absoluteOutput);
+  };
+
+  await writeOutput(payload);
+
+  if (!options.dryRun && options.force) {
+    process.stderr.write('Force flag ignored because automation merge is disabled in this build.\n');
+  }
+};
+
+run().catch((error) => {
+  exitWith(1, error instanceof Error ? error.message : String(error));
+});


### PR DESCRIPTION
## Summary
- add a hardened PowerShell automation script with GitHub token validation, structured logging, and atomic report writes
- create a triage CLI that validates credentials before calling the GitHub API and supports dry runs
- provide a lightweight agent health server plus pm2 ecosystem configuration for predictable startup

## Testing
- GITHUB_TOKEN=ghp_mock GITHUB_API_BASE=http://127.0.0.1:4000 npm run triage:prs -- --repo brandonlacoste9-tech/adgenxai --dry-run --limit 5 --output -
- node agents/github-pr-manager/dist/index.js & curl -s http://127.0.0.1:3001/health

------
https://chatgpt.com/codex/tasks/task_b_690862c01948832ea30805e38e3a4bf5